### PR TITLE
修复平台展开时直接替换方块的问题

### DIFF
--- a/src/main/java/dev/celestiacraft/industrialplatform/api/BlockMatcher.java
+++ b/src/main/java/dev/celestiacraft/industrialplatform/api/BlockMatcher.java
@@ -1,0 +1,38 @@
+package dev.celestiacraft.industrialplatform.api;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.List;
+
+public class BlockMatcher {
+	public static boolean matches(BlockState state, ForgeConfigSpec.ConfigValue<List<? extends String>> configValue) {
+		List<? extends String> entries = configValue.get();
+
+		for (String entry : entries) {
+			if (entry.startsWith("#")) {
+				String tagId = entry.substring(1);
+				ResourceLocation loc = ResourceLocation.tryParse(tagId);
+
+				if (loc != null) {
+					TagKey<Block> tag = BlockTags.create(loc);
+					if (state.is(tag)) {
+						return true;
+					}
+				}
+			} else {
+				ResourceLocation location = ResourceLocation.tryParse(entry);
+				Block block = location == null ? null : ForgeRegistries.BLOCKS.getValue(location);
+				if (block != null && state.is(block)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/dev/celestiacraft/industrialplatform/api/IPLogic.java
+++ b/src/main/java/dev/celestiacraft/industrialplatform/api/IPLogic.java
@@ -6,31 +6,35 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
-import dev.celestiacraft.industrialplatform.IndustrialPlatform;
+import net.minecraftforge.registries.ForgeRegistries;
+import dev.celestiacraft.industrialplatform.config.CommonConfig;
 
 import java.util.Optional;
 
 public class IPLogic {
+	private static final String MODID = "industrial_platform";
+
 	public static void placeStructure(ServerLevel level, int x, int y, int z, String structureId) {
 		StructureTemplateManager manager = level.getStructureManager();
-		ResourceLocation structureName = IndustrialPlatform.loadResource(structureId);
+		ResourceLocation structureName = loadResource(structureId);
 		Optional<StructureTemplate> template = manager.get(structureName);
 		template.ifPresent((temp) -> {
 			temp.placeInWorld(
 					level,
 					new BlockPos(x, y, z),
 					new BlockPos(x, y, z),
-					new StructurePlaceSettings()
-							.setRotation(Rotation.NONE)
-							.setMirror(Mirror.NONE)
-							.setIgnoreEntities(false),
+					createSafePlaceSettings(level),
 					level.random,
 					3
 			);
@@ -39,7 +43,7 @@ public class IPLogic {
 
 	public static void placeExtendedStructure(ServerLevel level, int x, int y, int z, String structureId) {
 		StructureTemplateManager manager = level.getStructureManager();
-		ResourceLocation structureName = IndustrialPlatform.loadResource(structureId);
+		ResourceLocation structureName = loadResource(structureId);
 		Optional<StructureTemplate> template = manager.get(structureName);
 		for (int i = x - 16; i <= x + 16; i = i + 16) {
 			for (int j = z - 16; j <= z + 16; j = j + 16) {
@@ -50,10 +54,7 @@ public class IPLogic {
 							level,
 							new BlockPos(finalI, y, finalJ),
 							new BlockPos(finalI, y, finalJ),
-							new StructurePlaceSettings()
-									.setRotation(Rotation.NONE)
-									.setMirror(Mirror.NONE)
-									.setIgnoreEntities(false),
+							createSafePlaceSettings(level),
 							level.random,
 							3
 					);
@@ -62,14 +63,19 @@ public class IPLogic {
 		}
 	}
 
+	private static StructurePlaceSettings createSafePlaceSettings(ServerLevel level) {
+		return new StructurePlaceSettings()
+				.setRotation(Rotation.NONE)
+				.setMirror(Mirror.NONE)
+				.setIgnoreEntities(false)
+				.addProcessor(new DropBeforePlaceProcessor(level));
+	}
+
 	public static void fillArea(ServerLevel level, int x0, int y0, int z0, int x1, int y1, int z1) {
 		for (int x = x0; x <= x1; x++) {
 			for (int y = y0; y <= y1; y++) {
 				for (int z = z0; z <= z1; z++) {
-					level.setBlockAndUpdate(
-							new BlockPos(x, y, z),
-							Blocks.AIR.defaultBlockState()
-					);
+					destroyIfBreakable(level, new BlockPos(x, y, z));
 				}
 			}
 		}
@@ -80,10 +86,7 @@ public class IPLogic {
 			for (int y = y0; y <= y1; y++) {
 				for (int z = z0; z <= z1; z++) {
 					BlockPos pos = new BlockPos(x, y, z);
-					BlockState state = level.getBlockState(pos);
-					if (state.isAir() || !state.getFluidState().isEmpty()) {
-						level.setBlockAndUpdate(pos, Blocks.STONE.defaultBlockState());
-					}
+					fillStoneIfOpen(level, pos);
 				}
 			}
 		}
@@ -94,6 +97,91 @@ public class IPLogic {
 
 		if (!player.isCreative()) {
 			stack.shrink(1);
+		}
+	}
+
+	private static boolean isUnbreakable(ServerLevel level, BlockPos pos, BlockState state) {
+		return state.getDestroySpeed(level, pos) < 0.0F;
+	}
+
+	private static boolean destroyIfBreakable(ServerLevel level, BlockPos pos) {
+		BlockState state = level.getBlockState(pos);
+		if (state.isAir() || isUnbreakable(level, pos, state)) {
+			return false;
+		}
+
+		level.destroyBlock(pos, shouldDrop(state));
+		return true;
+	}
+
+	private static boolean fillStoneIfOpen(ServerLevel level, BlockPos pos) {
+		BlockState state = level.getBlockState(pos);
+		if (!state.isAir() && !(state.getBlock() instanceof LiquidBlock)) {
+			return false;
+		}
+
+		level.setBlockAndUpdate(pos, Blocks.STONE.defaultBlockState());
+		return true;
+	}
+
+	private static boolean clearForTemplateAir(ServerLevel level, BlockPos pos, BlockState state) {
+		if (state.isAir() || isUnbreakable(level, pos, state)) {
+			return false;
+		}
+
+		level.destroyBlock(pos, shouldDrop(state));
+		return true;
+	}
+
+	private static boolean shouldDrop(BlockState state) {
+		ResourceLocation blockId = ForgeRegistries.BLOCKS.getKey(state.getBlock());
+		return !loadResource("industrial_platform").equals(blockId)
+				&& !loadResource("fluid_pool").equals(blockId)
+				&& !BlockMatcher.matches(state, CommonConfig.NO_DROP_BLOCKS);
+	}
+
+	private static ResourceLocation loadResource(String path) {
+		return ResourceLocation.fromNamespaceAndPath(MODID, path);
+	}
+
+	private static class DropBeforePlaceProcessor extends StructureProcessor {
+		private final ServerLevel level;
+
+		private DropBeforePlaceProcessor(ServerLevel level) {
+			this.level = level;
+		}
+
+		@Override
+		public StructureTemplate.StructureBlockInfo processBlock(
+				LevelReader levelReader,
+				BlockPos offset,
+				BlockPos pos,
+				StructureTemplate.StructureBlockInfo originalBlockInfo,
+				StructureTemplate.StructureBlockInfo currentBlockInfo,
+				StructurePlaceSettings settings
+		) {
+			BlockPos targetPos = currentBlockInfo.pos();
+			BlockState targetState = level.getBlockState(targetPos);
+
+			if (isUnbreakable(level, targetPos, targetState)) {
+				return null;
+			}
+
+			if (currentBlockInfo.state().isAir()) {
+				clearForTemplateAir(level, targetPos, targetState);
+				return currentBlockInfo;
+			}
+
+			if (!targetState.isAir()) {
+				level.destroyBlock(targetPos, shouldDrop(targetState));
+			}
+
+			return currentBlockInfo;
+		}
+
+		@Override
+		protected StructureProcessorType<?> getType() {
+			return StructureProcessorType.NOP;
 		}
 	}
 }

--- a/src/main/java/dev/celestiacraft/industrialplatform/config/CommonConfig.java
+++ b/src/main/java/dev/celestiacraft/industrialplatform/config/CommonConfig.java
@@ -9,6 +9,7 @@ public class CommonConfig {
 
 	public static final ForgeConfigSpec.ConfigValue<List<? extends String>> TRIGGER_BLOCK;
 	public static final ForgeConfigSpec.ConfigValue<List<? extends String>> ADJUSTER;
+	public static final ForgeConfigSpec.ConfigValue<List<? extends String>> NO_DROP_BLOCKS;
 	public static final ForgeConfigSpec.IntValue TOP_FILLING_DISTANCE;
 	public static final ForgeConfigSpec.IntValue BOTTOM_FILLING_DISTANCE;
 
@@ -33,6 +34,17 @@ public class CommonConfig {
 				.defineListAllowEmpty(
 						"adjuster",
 						List.of("#forge:tools/wrench", "minecraft:stick"),
+						CommonConfig::validateString
+				);
+
+		NO_DROP_BLOCKS = BUILDER
+				.comment("Blocks that should be destroyed without drops during platform deployment.")
+				.comment("Use \"#namespace:path\" for block tags, \"namespace:path\" for block IDs.")
+				.comment("Defaults are driven by the industrial_platform:no_drop_blocks block tag.")
+				.comment("Examples: \"#industrial_platform:no_drop_blocks\", \"#forge:stone\", \"minecraft:dirt\"")
+				.defineListAllowEmpty(
+						"no_drop_blocks",
+						List.of("#industrial_platform:no_drop_blocks"),
 						CommonConfig::validateString
 				);
 

--- a/src/main/resources/data/industrial_platform/tags/blocks/no_drop_blocks.json
+++ b/src/main/resources/data/industrial_platform/tags/blocks/no_drop_blocks.json
@@ -1,0 +1,40 @@
+{
+	"replace": false,
+	"values": [
+		{
+			"id": "#forge:stone",
+			"required": false
+		},
+		{
+			"id": "#forge:cobblestone",
+			"required": false
+		},
+		{
+			"id": "#forge:deepslate",
+			"required": false
+		},
+		"minecraft:stone",
+		"minecraft:granite",
+		"minecraft:diorite",
+		"minecraft:andesite",
+		"minecraft:cobblestone",
+		"minecraft:deepslate",
+		"minecraft:cobbled_deepslate",
+		"minecraft:tuff",
+		"minecraft:calcite",
+		"minecraft:dirt",
+		"minecraft:grass_block",
+		"minecraft:gravel",
+		"minecraft:sand",
+		"minecraft:sandstone",
+		"minecraft:chiseled_sandstone",
+		"minecraft:cut_sandstone",
+		"minecraft:smooth_sandstone",
+		"minecraft:red_sandstone",
+		"minecraft:chiseled_red_sandstone",
+		"minecraft:cut_red_sandstone",
+		"minecraft:smooth_red_sandstone",
+		"minecraft:netherrack",
+		"minecraft:end_stone"
+	]
+}


### PR DESCRIPTION
## 概述

修复工业平台/流体池展开时直接替换目标方块导致的安全问题。

原逻辑在清理区域和放置结构时会直接替换方块，可能导致机器、箱子、管道等玩家财产被静默删除，也可能覆盖基岩、屏障等不应被破坏的方块。

## 改动内容

- 结构放置时增加目标方块检查：
  - 不可破坏方块保留，结构对应位置跳过。
  - 可破坏方块先破坏，再放置结构方块。
- 上方清理不再直接设为空气，而是走破坏逻辑。
- 新增 `no_drop_blocks` 配置，用于控制哪些方块施工时破坏但不掉落。
- 新增默认方块标签 `industrial_platform:no_drop_blocks`，用于避免流体池展开时产生大量普通地形掉落物。

## 当前行为

展开时的处理规则为：

- 基岩、屏障等不可破坏方块：保留原样。
- 命中 `#industrial_platform:no_drop_blocks` 的方块：破坏但不掉落。
- 其他可破坏方块：破坏并正常掉落。

## 配置与数据包

默认 `no_drop_blocks` 配置为：

```txt
#industrial_platform:no_drop_blocks
```

整合包作者可以通过 datapack 扩展该标签：

```txt
data/industrial_platform/tags/blocks/no_drop_blocks.json
```

也可以在 common config 中额外添加 block id 或 block tag。

## 为什么这样改

这样可以避免玩家财产被直接替换删除，同时也避免流体池这类大范围结构展开时生成大量普通地形掉落物造成卡顿。